### PR TITLE
Various changes to facilitate dumping of Math::Symbolic trees

### DIFF
--- a/math-symbolic/examples/tree_dump.pl
+++ b/math-symbolic/examples/tree_dump.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Math::Symbolic qw(:all);
+
+# Use some tree dump modules
+use Text::Tree;
+use Tree::To::TextLines qw(render_tree_as_text);
+# can also use Tree::Dump but output is not as useful
+
+# We're working with some Math::Symbolic expression
+my $expr = parse_from_string("u*t + (1/2)*a*t^2");
+
+# We want to see what the tree looks like for some reason
+print qq{"$expr" in tree form.\n\n};
+
+# View it with Tree::To::TextLines
+print "Tree::To::TextLines:\n\n";
+print render_tree_as_text({show_guideline => 1, id_attribute => 'tid',}, $expr), "\n\n";
+
+# View it with Text::Tree
+print "Text::Tree:\n\n";
+my $text_tree = new Text::Tree( $expr->to_text_tree() );
+print $text_tree->layout("spaced and centered in ovals"), "\n\n";
+
+

--- a/math-symbolic/lib/Math/Symbolic/Base.pm
+++ b/math-symbolic/lib/Math/Symbolic/Base.pm
@@ -618,6 +618,28 @@ sub set_value {
 
 =begin comment
 
+We define methods "children()" and "tid()" to facilitate tree dumping
+with Tree::Dump, and even better, with Tree::To::TextLines. See 
+tree_dump.pl in the examples.
+
+These methods are implemented in Operator.pm but not in Variable.pm and
+Constant.pm, as they can use these methods from the base class.
+
+=end comment
+
+=cut
+
+sub children {
+    return undef;
+}
+
+sub tid {
+    my $self = shift;
+    return $self->to_string();
+}
+
+=begin comment
+
 Since version 0.102, there are several overloaded operators. The overloaded
 interface is documented below. For more info, please have a look at the
 Math::Symbolic man page.

--- a/math-symbolic/lib/Math/Symbolic/Custom/DefaultDumpers.pm
+++ b/math-symbolic/lib/Math/Symbolic/Custom/DefaultDumpers.pm
@@ -109,6 +109,37 @@ sub to_sub {
     return Math::Symbolic::Compiler->compile_to_sub( $self, $args );
 }
 
+=head2 to_text_tree
+
+Text::Tree is a module that can display a nicely formatted tree using text 
+strings. This method will export a Math::Symbolic expression tree in a format 
+that can be used by the Text::Tree constructor.
+
+See the tree_dump.pl example and L<Text::Tree>.
+
+=cut
+
+sub to_text_tree  {
+    my $t = shift;
+    my @e;
+
+    if ( ($t->term_type() == T_VARIABLE) || ($t->term_type() == T_CONSTANT) ) {
+        push @e, $t->to_string();
+    }
+    else {
+        my $op_info = $Math::Symbolic::Operator::Op_Types[$t->type()];
+        my $op_str = defined($op_info->{infix_string}) ? $op_info->{infix_string} : $op_info->{prefix_string};
+
+        push @e, $op_str;
+        foreach my $c ( $t->children() ) {
+            push @e, [ to_text_tree($c) ];
+        }
+    }
+
+    return @e;
+}
+
+
 1;
 __END__
 

--- a/math-symbolic/lib/Math/Symbolic/Operator.pm
+++ b/math-symbolic/lib/Math/Symbolic/Operator.pm
@@ -1070,6 +1070,25 @@ sub explicit_signature {
     return sort keys %sig;
 }
 
+=head2 Methods children and tid
+
+children() and tid() are implemented here to facilitate tree dumping
+with Tree::Dump and Tree::To::TextLines. See tree_dump.pl in the examples.
+
+=cut
+
+sub children {
+    my $self = shift;
+    return @{ $self->{operands} };
+}
+
+sub tid {
+    my $self = shift;
+    my $op_info = $Op_Types[$self->type()];
+    my $op_str = defined($op_info->{infix_string}) ? $op_info->{infix_string} : $op_info->{prefix_string};
+    return "'$op_str' { subexpression: '" . $self->to_string() . "'}";
+}
+
 1;
 __END__
 


### PR DESCRIPTION
It is sometimes useful to be able to view the Math::Symbolic tree. The changes here facilitate use of two tree viewing modules, Text::Tree and Tree::Dump (also Tree:To::TextLines which it uses). There is an example showing how the changes work.
